### PR TITLE
Rewrite Adb connection to fix pulling from Oreo

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -24,15 +24,8 @@ dependencies {
 
     implementation 'com.android.tools.build:gradle:3.4.2'
 
-    implementation 'com.squareup.okhttp3:okhttp:3.7.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.7.0'
-    implementation 'com.google.code.gson:gson:2.8.0'
-    implementation 'com.android.tools.ddms:ddmlib:25.3.0'
-
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.30'
-    testImplementation 'commons-io:commons-io:2.5'
-    testImplementation 'com.github.geowarin:docker-junit-rule:1.1.0'
 }
 
 tasks.named('test') {

--- a/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/Adb.kt
+++ b/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/Adb.kt
@@ -1,7 +1,6 @@
 package com.sloydev.screenshotreporter.gradle
 
 import java.io.File
-import java.util.regex.Pattern
 
 class Adb(private val adbBinaryPath: File, private val logEnabled: Boolean = true) {
 
@@ -17,41 +16,41 @@ class Adb(private val adbBinaryPath: File, private val logEnabled: Boolean = tru
   }
 
   fun getExternalStoragePath(device: DeviceId): RemoteFile {
-    return executeCommandOnDevice(device, "shell echo \$EXTERNAL_STORAGE")
+    return device.executeCommandOnDevice("shell", "echo", "\$EXTERNAL_STORAGE")
         .trim()
         .let { RemoteFile(it) }
   }
 
   fun pullFolder(device: DeviceId, deviceFolder: RemoteFile, outputFolder: File) {
-    executeCommandOnDevice(device, "pull ${deviceFolder.escapedPath} ${outputFolder.escapedPath}")
+    device.executeCommandOnDevice("pull", deviceFolder.path, outputFolder.absolutePath)
   }
 
   fun pushFile(device: DeviceId, localFile: File, deviceFile: RemoteFile) {
-    executeCommandOnDevice(device, "push ${localFile.escapedPath} ${deviceFile.escapedPath}")
+    device.executeCommandOnDevice("push", localFile.absolutePath, deviceFile.path)
   }
 
   fun clearFolder(device: DeviceId, deviceFolder: RemoteFile) {
-    executeCommandOnDevice(device, "shell rm -rf ${deviceFolder.escapedPath}")
+    device.executeCommandOnDevice("shell", "rm -rf", deviceFolder.path)
   }
 
   fun getApiLevel(device: DeviceId): Int {
-    return executeCommandOnDevice(device, "shell getprop ro.build.version.sdk").trim().toInt()
+    return device.executeCommandOnDevice("shell", "getprop ro.build.version.sdk").trim().toInt()
   }
 
   fun grantExternalStoragePermission(device: DeviceId, appPackage: String) {
-    executeCommandOnDevice(device, "pm grant $appPackage android.permission.READ_EXTERNAL_STORAGE")
-    executeCommandOnDevice(device, "pm grant $appPackage android.permission.WRITE_EXTERNAL_STORAGE")
+    device.executeCommandOnDevice("shell", "pm", "grant", appPackage, "android.permission.READ_EXTERNAL_STORAGE")
+    device.executeCommandOnDevice("shell", "pm", "grant", appPackage, "android.permission.WRITE_EXTERNAL_STORAGE")
   }
 
-  private fun executeCommandOnDevice(device: DeviceId, command: String): String {
-    return executeAdbCommand("-s ${device.serialNumber} $command")
+  private fun DeviceId.executeCommandOnDevice(vararg command: String): String {
+    return executeAdbCommand("-s", this.serialNumber, *command)
   }
 
-  private fun executeAdbCommand(command: String): String {
+  private fun executeAdbCommand(vararg command: String): String {
     if (logEnabled) {
-      println("$ adb $command")
+      println("$ adb ${command.joinToString(" ")}")
     }
-    Runtime.getRuntime().exec("${adbBinaryPath.absolutePath} $command").inputStream.reader().use { reader ->
+    Runtime.getRuntime().exec(arrayOf(adbBinaryPath.absolutePath, *command)).inputStream.reader().use { reader ->
       val response = reader.readText().also { commandResponse ->
         println(commandResponse.trim().split("\n").joinToString("\n") { "> $it" } + "\n")
       }
@@ -77,14 +76,6 @@ open class AdbException(message: String) : RuntimeException(message)
 class AdbNoSuchFileOrDirectoryException(message: String) : AdbException(message)
 
 data class DeviceId(val serialNumber: String)
-class RemoteFile(private val path: String) {
-  val escapedPath: String
-    get() = fileEscapePattern.matcher(path).replaceAll("\\\\$1")
-
+class RemoteFile(val path: String) {
   fun resolve(relative: String) = RemoteFile(path + File.separator + relative)
 }
-
-private val fileEscapePattern = Pattern.compile("([\\\\()*+?\"'&#\\s])")
-
-private val File.escapedPath
-  get() = fileEscapePattern.matcher(absolutePath).replaceAll("\\\\$1")

--- a/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/Adb.kt
+++ b/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/Adb.kt
@@ -1,0 +1,90 @@
+package com.sloydev.screenshotreporter.gradle
+
+import java.io.File
+import java.util.regex.Pattern
+
+class Adb(private val adbBinaryPath: File, private val logEnabled: Boolean = true) {
+
+  fun devices(): List<DeviceId> {
+    return executeAdbCommand("devices")
+        .trim()
+        .split('\n').drop(1)
+        .filter { it.isNotBlank() }
+        .map { line ->
+          line.split('\t').first()
+        }
+        .map { DeviceId(it) }
+  }
+
+  fun getExternalStoragePath(device: DeviceId): RemoteFile {
+    return executeCommandOnDevice(device, "shell echo \$EXTERNAL_STORAGE")
+        .trim()
+        .let { RemoteFile(it) }
+  }
+
+  fun pullFolder(device: DeviceId, deviceFolder: RemoteFile, outputFolder: File) {
+    executeCommandOnDevice(device, "pull ${deviceFolder.escapedPath} ${outputFolder.escapedPath}")
+  }
+
+  fun pushFile(device: DeviceId, localFile: File, deviceFile: RemoteFile) {
+    executeCommandOnDevice(device, "push ${localFile.escapedPath} ${deviceFile.escapedPath}")
+  }
+
+  fun clearFolder(device: DeviceId, deviceFolder: RemoteFile) {
+    executeCommandOnDevice(device, "shell rm -rf ${deviceFolder.escapedPath}")
+  }
+
+  fun getApiLevel(device: DeviceId): Int {
+    return executeCommandOnDevice(device, "shell getprop ro.build.version.sdk").trim().toInt()
+  }
+
+  fun grantExternalStoragePermission(device: DeviceId, appPackage: String) {
+    executeCommandOnDevice(device, "pm grant $appPackage android.permission.READ_EXTERNAL_STORAGE")
+    executeCommandOnDevice(device, "pm grant $appPackage android.permission.WRITE_EXTERNAL_STORAGE")
+  }
+
+  private fun executeCommandOnDevice(device: DeviceId, command: String): String {
+    return executeAdbCommand("-s ${device.serialNumber} $command")
+  }
+
+  private fun executeAdbCommand(command: String): String {
+    if (logEnabled) {
+      println("$ adb $command")
+    }
+    Runtime.getRuntime().exec("${adbBinaryPath.absolutePath} $command").inputStream.reader().use { reader ->
+      val response = reader.readText().also { commandResponse ->
+        println(commandResponse.trim().split("\n").joinToString("\n") { "> $it" } + "\n")
+      }
+      return parseResponse(response)
+    }
+  }
+
+  private fun parseResponse(response: String): String {
+    if (response.startsWith("adb: error:")) {
+      val message = response.removePrefix("adb: error:").trim()
+      if (message.endsWith("No such file or directory")) {
+        throw AdbNoSuchFileOrDirectoryException(response)
+      } else {
+        throw AdbException(message)
+      }
+    } else {
+      return response.trim()
+    }
+  }
+}
+
+open class AdbException(message: String) : RuntimeException(message)
+class AdbNoSuchFileOrDirectoryException(message: String) : AdbException(message)
+
+data class DeviceId(val serialNumber: String)
+class RemoteFile(private val path: String) {
+  val escapedPath: String
+    get() = fileEscapePattern.matcher(path).replaceAll("\\\\$1")
+
+  fun resolve(relative: String) = RemoteFile(path + File.separator + relative)
+}
+
+private val fileEscapePattern = Pattern.compile("([\\\\()*+?\"'&#\\s])")
+
+private val File.escapedPath
+  get() = fileEscapePattern.matcher(absolutePath).replaceAll("\\\\$1")

--- a/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporter.kt
+++ b/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporter.kt
@@ -34,7 +34,7 @@ class ScreenshotReporter(val appPackage: String, sdkDirectory: File) {
   fun cleanScreenshotsFromDevice() {
     val device = getRunningDevice()
     val screenshotsFolder = adb.getExternalStoragePath(device).resolve(DEVICE_SCREENSHOT_DIR)
-    println("Cleaning existing screenshots on \"${screenshotsFolder.escapedPath}\" from device [${device.serialNumber}]...")
+    println("Cleaning existing screenshots on \"${screenshotsFolder.path}\" from device [${device.serialNumber}]...")
     adb.clearFolder(device, screenshotsFolder)
   }
 
@@ -57,7 +57,7 @@ class ScreenshotReporter(val appPackage: String, sdkDirectory: File) {
   private fun pullExternalDirectory(device: DeviceId, directoryName: String, outputDir: File) {
     // Output path on public external storage, for Lollipop and above.
     val externalDir: RemoteFile = adb.getExternalStoragePath(device).resolve(directoryName)
-    println("Pulling files from \"${externalDir.escapedPath}\" on device [${device.serialNumber}]...")
+    println("Pulling files from \"${externalDir.path}\" on device [${device.serialNumber}]...")
     try {
       adb.pullFolder(device, externalDir, outputDir)
     } catch (noDirectoryException: AdbNoSuchFileOrDirectoryException) {

--- a/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporter.kt
+++ b/plugin/src/main/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporter.kt
@@ -1,180 +1,67 @@
 package com.sloydev.screenshotreporter.gradle
 
-import com.android.ddmlib.AndroidDebugBridge
-import com.android.ddmlib.CollectingOutputReceiver
-import com.android.ddmlib.FileListingService
-import com.android.ddmlib.FileListingService.TYPE_DIRECTORY
-import com.android.ddmlib.IDevice
-import com.android.ddmlib.SyncService
-import com.android.ddmlib.SyncService.getNullProgressMonitor
 import java.io.File
-import java.time.Duration
-import java.util.concurrent.TimeUnit
 
-class ScreenshotReporter(val appPackage: String, val sdkDirectory: File) {
+class ScreenshotReporter(val appPackage: String, sdkDirectory: File) {
 
-    companion object {
-        val DEVICE_SCREENSHOT_DIR = "app_spoon-screenshots"
-        val MARSHMALLOW_API_LEVEL = 23
-    }
+  private val adbPath = sdkDirectory.resolve("platform-tools").resolve("adb")
+  val adb = Adb(adbPath)
 
-    fun pullScreenshots(outputDir: File) {
-        outputDir.deleteRecursively()
-        outputDir.mkdirs()
+  companion object {
+    val DEVICE_SCREENSHOT_DIR = "app_spoon-screenshots"
+    val MARSHMALLOW_API_LEVEL = 23
+  }
 
-        val adb = getAdb()
-        val singleDevice = getRunningDevice(adb)
-        pullDirectory(singleDevice, DEVICE_SCREENSHOT_DIR, outputDir)
-        simplifyDirectoryStructure(outputDir)
+  fun pullScreenshots(outputDir: File) {
+    outputDir.deleteRecursively()
+    outputDir.mkdirs()
 
-        println("Wrote screenshots report to file://${outputDir.absolutePath}")
-    }
+    val singleDevice = getRunningDevice()
+    pullExternalDirectory(singleDevice, DEVICE_SCREENSHOT_DIR, outputDir)
+    simplifyDirectoryStructure(outputDir)
 
-    private fun simplifyDirectoryStructure(outputDir: File) {
-        outputDir.resolve(DEVICE_SCREENSHOT_DIR).listFiles().forEach { subDir ->
-            subDir.renameTo(outputDir.resolve(subDir.name))
+    println("Wrote screenshots report to file://${outputDir.absolutePath}")
+  }
+
+  private fun simplifyDirectoryStructure(outputDir: File) {
+    outputDir.resolve(DEVICE_SCREENSHOT_DIR).listFiles().orEmpty()
+        .forEach { subDir ->
+          subDir.renameTo(outputDir.resolve(subDir.name))
         }
-        outputDir.resolve(DEVICE_SCREENSHOT_DIR).delete()
+    outputDir.resolve(DEVICE_SCREENSHOT_DIR).delete()
+  }
+
+  fun cleanScreenshotsFromDevice() {
+    val device = getRunningDevice()
+    val screenshotsFolder = adb.getExternalStoragePath(device).resolve(DEVICE_SCREENSHOT_DIR)
+    println("Cleaning existing screenshots on \"${screenshotsFolder.escapedPath}\" from device [${device.serialNumber}]...")
+    adb.clearFolder(device, screenshotsFolder)
+  }
+
+  fun grantPermissions() {
+    val device = getRunningDevice()
+    val apiLevel = adb.getApiLevel(device)
+    if (apiLevel >= MARSHMALLOW_API_LEVEL) {
+      println("Granting read/write storage permission to device [${device.serialNumber}]...")
+      adb.grantExternalStoragePermission(device, appPackage)
     }
+  }
 
-    fun cleanScreenshotsFromDevice() {
-        with(getRunningDevice(getAdb())) {
-            val outputReceiver = CollectingOutputReceiver()
-            val externalPath = getExternalStoragePath(this, DEVICE_SCREENSHOT_DIR)
-            val command = "rm -rf $externalPath"
+  private fun getRunningDevice(): DeviceId {
+    val devices = adb.devices()
+    check(devices.isNotEmpty()) { "No devices found" }
+    check(devices.size == 1) { "More than one device, not supported for now :(" }
+    return devices[0]
+  }
 
-            executeShellCommand(command, outputReceiver)
-        }
+  private fun pullExternalDirectory(device: DeviceId, directoryName: String, outputDir: File) {
+    // Output path on public external storage, for Lollipop and above.
+    val externalDir: RemoteFile = adb.getExternalStoragePath(device).resolve(directoryName)
+    println("Pulling files from \"${externalDir.escapedPath}\" on device [${device.serialNumber}]...")
+    try {
+      adb.pullFolder(device, externalDir, outputDir)
+    } catch (noDirectoryException: AdbNoSuchFileOrDirectoryException) {
+      println("Warning: Directory not found on device, no screenshots were pulled.")
     }
-
-    fun grantPermissions() {
-        val device = getRunningDevice(getAdb())
-        val apiLevel = device.getProperty("ro.build.version.sdk").toInt()
-        if (apiLevel >= MARSHMALLOW_API_LEVEL) {
-            val grantOutputReceiver = CollectingOutputReceiver()
-            device.executeShellCommand(
-                    "pm grant $appPackage android.permission.READ_EXTERNAL_STORAGE",
-                    grantOutputReceiver)
-            device.executeShellCommand(
-                    "pm grant $appPackage android.permission.WRITE_EXTERNAL_STORAGE",
-                    grantOutputReceiver)
-        }
-    }
-
-    fun getRunningDevice(adb: AndroidDebugBridge): IDevice {
-        val devices = adb.devices
-        check(devices.isNotEmpty(), { "No devices found" })
-        check(devices.size == 1, { "More than one device, not supported for now :(" })
-
-        val singleDevice = devices[0]
-        return singleDevice
-    }
-
-    fun getAdb(): AndroidDebugBridge {
-        val adbPath = sdkDirectory.resolve("platform-tools").resolve("adb")
-
-        AndroidDebugBridge.initIfNeeded(true)
-        val adb = AndroidDebugBridge.createBridge(adbPath.absolutePath, false)
-
-        waitForAdb(adb, Duration.ofSeconds(30))
-        return adb
-    }
-
-    private fun waitForAdb(adb: AndroidDebugBridge, timeOut: Duration) {
-        var timeOutMs = timeOut.toMillis()
-        val sleepTimeMs = TimeUnit.SECONDS.toMillis(1)
-        while (!adb.hasInitialDeviceList() && timeOutMs > 0) {
-            try {
-                Thread.sleep(sleepTimeMs)
-            } catch (e: InterruptedException) {
-                throw RuntimeException(e)
-            }
-
-            timeOutMs -= sleepTimeMs
-        }
-        if (timeOutMs <= 0 && !adb.hasInitialDeviceList()) {
-            throw RuntimeException("Timeout getting device list.")
-        }
-    }
-
-    private fun pullDirectory(device: IDevice, name: String, outputDir: File) {
-        // Output path on private internal storage, for KitKat and below.
-        //val internalDir = getDirectoryOnInternalStorage(name)
-        //println("Internal path is " + internalDir.getFullPath())
-
-        // Output path on public external storage, for Lollipop and above.
-        val externalDir = getDirectoryOnExternalStorage(device, name)
-        println("External path is " + externalDir.getFullPath())
-
-        // Sync test output files to the local filesystem.
-        println("Pulling files from external dir on [${device.serialNumber}]")
-        val localDirName = outputDir.absolutePath
-        adbPull(device, externalDir, localDirName)
-
-        //println("Pulling files from internal dir on [${device.serialNumber}]")
-        //adbPull(device, internalDir, localDirName)
-        //println("Done pulling $name from on [${device.serialNumber}]")
-    }
-}
-
-private fun getDirectoryOnExternalStorage(device: IDevice, dir: String): FileListingService.FileEntry {
-    val externalPath = getExternalStoragePath(device, dir)
-    return obtainDirectoryFileEntry(externalPath)
-}
-
-fun getExternalStoragePath(device: IDevice, path: String): String {
-    val pathNameOutputReceiver = CollectingOutputReceiver()
-    device.executeShellCommand("echo \$EXTERNAL_STORAGE", pathNameOutputReceiver)
-    return pathNameOutputReceiver.output.trim { it <= ' ' } + "/" + path
-}
-
-/** Get a [FileEntry] for an arbitrary path.  */
-private fun obtainDirectoryFileEntry(path: String): FileListingService.FileEntry {
-    // Dark magic here
-    val constructor = FileListingService.FileEntry::class.java.getDeclaredConstructor(FileListingService.FileEntry::class.java, String::class.java, Int::class.javaPrimitiveType,
-            Boolean::class.javaPrimitiveType)
-    constructor.isAccessible = true
-
-    var lastEntry: FileListingService.FileEntry? = null
-    for (part in path.split("/")) {
-        lastEntry = constructor.newInstance(lastEntry, part, TYPE_DIRECTORY, lastEntry == null)
-    }
-    return lastEntry ?: throw RuntimeException("No entries for $path")
-}
-
-private fun adbPull(device: IDevice, remoteDirName: FileListingService.FileEntry, localDirName: String) {
-    getNullProgressMonitor()
-    val progressMonitor: SyncService.ISyncProgressMonitor = object : SyncProgressMonitorAdapter() {
-        override fun start(totalWork: Int) {
-            println("-> start pulling files")
-        }
-
-        override fun startSubTask(name: String) {
-            println("pulling $name ...")
-        }
-
-        override fun stop() {
-            println("<- done.")
-        }
-    }
-    device.syncService.pull(arrayOf(remoteDirName), localDirName, progressMonitor)
-}
-
-open class SyncProgressMonitorAdapter : SyncService.ISyncProgressMonitor {
-
-    override fun startSubTask(name: String) {
-    }
-
-    override fun start(totalWork: Int) {
-    }
-
-    override fun stop() {
-    }
-
-    override fun isCanceled(): Boolean {
-        return false
-    }
-
-    override fun advance(work: Int) {
-    }
+  }
 }

--- a/plugin/src/test/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporterTest.kt
+++ b/plugin/src/test/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporterTest.kt
@@ -112,7 +112,7 @@ class ScreenshotReporterTest {
     }
 
     private fun pushFilesToDevice(files: Array<String>) {
-        val device = screenshotReporter.adb.devices().first()
+        val device = screenshotReporter.currentDevice
         files.map {  inputTestFolder.resolve(it) }
             .forEach { localTestFile -> localTestFile.createNewFile() }
         val deviceFile = screenshotReporter.adb.getExternalStoragePath(device)

--- a/plugin/src/test/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporterTest.kt
+++ b/plugin/src/test/kotlin/com/sloydev/screenshotreporter/gradle/ScreenshotReporterTest.kt
@@ -13,7 +13,7 @@ class ScreenshotReporterTest {
 
     @get:Rule
     val temporaryFolder = TemporaryFolder()
-//    val permanentFolder = File("test-output")
+//    val permanentFolder = File("test-files")
 
     lateinit var outputFolder: File
     lateinit var inputTestFolder: File
@@ -24,7 +24,7 @@ class ScreenshotReporterTest {
     @Before
     fun setUp() {
         outputFolder = temporaryFolder.newFolder("outputs")
-//        outputFolder = permanentFolder.also { it.mkdirs() }
+//        outputFolder = permanentFolder.resolve("outputs").also { it.mkdirs() }
         inputTestFolder = temporaryFolder.newFolder("inputs")
 //        inputTestFolder = permanentFolder.resolve("inputs").also { it.mkdirs() }
         nonExistentOutputFolder = temporaryFolder.root.resolve("another_output")
@@ -52,7 +52,7 @@ class ScreenshotReporterTest {
         val exportedFileNames = exportedFiles.map { it.name }
 
         assertThat(exportedFileNames)
-                .containsAllOf("screenshot1.png", "screenshot2.png")
+                .containsAllOf("screenshot 1.png", "screenshot2.png")
     }
 
     @Test
@@ -108,19 +108,16 @@ class ScreenshotReporterTest {
     }
 
     private fun givenDeviceHasReportFiles() {
-        pushFilesToDevice(arrayOf("screenshot1.png", "screenshot2.png"))
+        pushFilesToDevice(arrayOf("screenshot 1.png", "screenshot2.png"))
     }
 
     private fun pushFilesToDevice(files: Array<String>) {
         val device = screenshotReporter.adb.devices().first()
         files.map {  inputTestFolder.resolve(it) }
-            .forEach { file ->
-              file.createNewFile()
-              val deviceFile = screenshotReporter.adb.getExternalStoragePath(device)
-                  .resolve(DEVICE_SCREENSHOT_DIR)
-                  .resolve(file.name)
-              println("device file: ${deviceFile.escapedPath}")
-              screenshotReporter.adb.pushFile(device, file, deviceFile)
-        }
+            .forEach { localTestFile -> localTestFile.createNewFile() }
+        val deviceFile = screenshotReporter.adb.getExternalStoragePath(device)
+            .resolve(DEVICE_SCREENSHOT_DIR)
+        println("Pushing \"${inputTestFolder.absolutePath}\" to device [${device.serialNumber}] on path \"${deviceFile}\"")
+        screenshotReporter.adb.pushFile(device, inputTestFolder, deviceFile)
     }
 }


### PR DESCRIPTION
Pulling files with whitespaces in their name from Oreo devices (or newer) would fail.
There was some issue with ddmlib, so I rewrote the Adb connection to use Java's `Runtime.getRuntime().exec()` to invoke ADB commands manually.

This fixes it :) 